### PR TITLE
Add word-level visualization prototype using sentence_plot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -219,3 +219,4 @@ __marimo__/
 
 project_text_shapiq.md
 src/shapiq/_version.py
+.DS_Store

--- a/tests/shapiq/tests_unit/tests_imputer/test_text_imputer.py
+++ b/tests/shapiq/tests_unit/tests_imputer/test_text_imputer.py
@@ -226,3 +226,30 @@ def test_mask_strategy_requires_mask_token(monkeypatch):
 
     with pytest.raises(ValueError, match="requires tokenizer.mask_token_id"):
         TextImputer("dummy", "I love NLP", mask_strategy="mask")
+
+def test_sentence_plot_with_word_players():
+    from shapiq.plot import sentence_plot
+    from shapiq.interaction_values import InteractionValues
+    import numpy as np
+
+    text = "RBG was a very good jurist"
+    imputer = TextImputer("dummy", text, segmentation="word")
+
+    words = imputer.players.tolist()
+
+    values = np.random.rand(len(words))
+
+    iv = InteractionValues(
+        values=values,
+        index="SV",
+        n_players=len(words),
+        min_order=1,
+        max_order=1,
+        estimated=False,
+        baseline_value=0.0,
+    )
+
+    fig, ax = sentence_plot(iv, words, show=False)
+
+    assert fig is not None
+    assert ax is not None

--- a/tests/shapiq/tests_unit/tests_imputer/test_text_imputer.py
+++ b/tests/shapiq/tests_unit/tests_imputer/test_text_imputer.py
@@ -227,10 +227,12 @@ def test_mask_strategy_requires_mask_token(monkeypatch):
     with pytest.raises(ValueError, match="requires tokenizer.mask_token_id"):
         TextImputer("dummy", "I love NLP", mask_strategy="mask")
 
+
 def test_sentence_plot_with_word_players():
-    from shapiq.plot import sentence_plot
-    from shapiq.interaction_values import InteractionValues
     import numpy as np
+
+    from shapiq.interaction_values import InteractionValues
+    from shapiq.plot import sentence_plot
 
     text = "RBG was a very good jurist"
     imputer = TextImputer("dummy", text, segmentation="word")


### PR DESCRIPTION
## Motivation and Context

This PR adds a minimal visualization prototype for TextImputer using the existing `sentence_plot` utility.

The goal is to verify that the current TextImputer output can be directly used for word-level attribution visualization.

## Scope

- Supports `segmentation="word"` only
- Uses `players` as visualization labels
- Assumes 1:1 alignment between words and attribution values

## What is included

- A test demonstrating integration between TextImputer and sentence_plot

## What is NOT included

- token-level visualization
- remove-strategy alignment
- interaction heatmaps

## Notes

This is a prototype PR to only establish a working visualization baseline.