### PR TITLE
Add sentence interaction heatmap visualization (Partially addresses #9)

### DIFF
--- a/src/shapiq/plot/__init__.py
+++ b/src/shapiq/plot/__init__.py
@@ -23,6 +23,7 @@ __all__ = [
     "bar_plot",
     "waterfall_plot",
     "sentence_plot",
+    "sentence_interaction_heatmap",
     "upset_plot",
     "beeswarm_plot",
     # utils

--- a/src/shapiq/plot/__init__.py
+++ b/src/shapiq/plot/__init__.py
@@ -8,7 +8,7 @@ from .bar import bar_plot
 from .beeswarm import beeswarm_plot
 from .force import force_plot
 from .network import network_plot
-from .sentence import sentence_plot
+from .sentence import sentence_interaction_heatmap, sentence_plot
 from .si_graph import si_graph_plot
 from .stacked_bar import stacked_bar_plot
 from .upset import upset_plot

--- a/src/shapiq/plot/sentence.py
+++ b/src/shapiq/plot/sentence.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import contextlib
+import numpy as np
 from typing import TYPE_CHECKING
 
 from matplotlib import pyplot as plt
@@ -199,5 +200,22 @@ def sentence_plot(
     # draw the plot
     if not show:
         return fig, ax
+    plt.show()
+    return None
+
+
+def sentence_interaction_heatmap(
+    interaction_values: InteractionValues,
+    words: Sequence[str],
+    *,
+    show: bool = False,
+) -> tuple[Figure, Axes] | None:
+    """Plot a minimal pairwise interaction heatmap for sentence players."""
+    # before: pass (Temporary placeholder)
+    fig, ax = plt.subplots()
+
+    if not show:
+        return fig, ax
+
     plt.show()
     return None

--- a/src/shapiq/plot/sentence.py
+++ b/src/shapiq/plot/sentence.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 import contextlib
-import numpy as np
 from typing import TYPE_CHECKING
 
+import numpy as np
 from matplotlib import pyplot as plt
 from matplotlib.font_manager import FontProperties
 from matplotlib.patches import FancyBboxPatch, PathPatch
@@ -209,7 +209,7 @@ def sentence_interaction_heatmap(
     words: Sequence[str],
     *,
     show: bool = False,
-    max_score: float | None = None, #color range of the heatmap
+    max_score: float | None = None,  # color range of the heatmap
 ) -> tuple[Figure, Axes] | None:
     """Plot a minimal pairwise interaction heatmap for sentence players."""
     # before: pass (Temporary placeholder)
@@ -217,7 +217,7 @@ def sentence_interaction_heatmap(
     # 2d matrix init
     n_words = len(words)
 
-    #player index debug
+    # player index debug
     if n_words != interaction_values.n_players:
         msg = (
             f"Number of words must match number of players. "
@@ -226,29 +226,24 @@ def sentence_interaction_heatmap(
         raise ValueError(msg)
 
     interaction_matrix = np.zeros((n_words, n_words))
-    
+
     # diagonal
     for i in range(n_words):
         interaction_matrix[i, i] = interaction_values[(i,)]
 
-    #pairwise interaction
+    # pairwise interaction
     for i in range(n_words):
         for j in range(i + 1, n_words):
             value = interaction_values[(i, j)]
             interaction_matrix[i, j] = value
             interaction_matrix[j, i] = value
 
-
-    if max_score is None:
-        max_abs_score = np.max(np.abs(interaction_matrix))
-    else:
-        max_abs_score = max_score
+    max_abs_score = np.max(np.abs(interaction_matrix)) if max_score is None else max_score
 
     if max_abs_score == 0:
         max_abs_score = 1.0
-        
 
-    #draw interaction matrix
+    # draw interaction matrix
     image = ax.imshow(
         interaction_matrix,
         cmap="coolwarm",
@@ -256,7 +251,7 @@ def sentence_interaction_heatmap(
         vmax=max_abs_score,
     )
 
-    #x&y achses show word/player lables
+    # x&y achses show word/player lables
     ax.set_xticks(np.arange(n_words))
     ax.set_yticks(np.arange(n_words))
     ax.set_xticklabels(words, rotation=45, ha="right")
@@ -268,7 +263,6 @@ def sentence_interaction_heatmap(
 
     fig.colorbar(image, ax=ax)
     fig.tight_layout()
-
 
     if not show:
         return fig, ax

--- a/src/shapiq/plot/sentence.py
+++ b/src/shapiq/plot/sentence.py
@@ -209,12 +209,21 @@ def sentence_interaction_heatmap(
     words: Sequence[str],
     *,
     show: bool = False,
+    max_score: float | None = None, #color range of the heatmap
 ) -> tuple[Figure, Axes] | None:
     """Plot a minimal pairwise interaction heatmap for sentence players."""
     # before: pass (Temporary placeholder)
     fig, ax = plt.subplots()
     # 2d matrix init
     n_words = len(words)
+
+    #player index debug
+    if n_words != interaction_values.n_players:
+        msg = (
+            f"Number of words must match number of players. "
+            f"Got {n_words} words and {interaction_values.n_players} players."
+        )
+        raise ValueError(msg)
 
     interaction_matrix = np.zeros((n_words, n_words))
     
@@ -228,6 +237,38 @@ def sentence_interaction_heatmap(
             value = interaction_values[(i, j)]
             interaction_matrix[i, j] = value
             interaction_matrix[j, i] = value
+
+
+    if max_score is None:
+        max_abs_score = np.max(np.abs(interaction_matrix))
+    else:
+        max_abs_score = max_score
+
+    if max_abs_score == 0:
+        max_abs_score = 1.0
+        
+
+    #draw interaction matrix
+    image = ax.imshow(
+        interaction_matrix,
+        cmap="coolwarm",
+        vmin=-max_abs_score,
+        vmax=max_abs_score,
+    )
+
+    #x&y achses show word/player lables
+    ax.set_xticks(np.arange(n_words))
+    ax.set_yticks(np.arange(n_words))
+    ax.set_xticklabels(words, rotation=45, ha="right")
+    ax.set_yticklabels(words)
+
+    ax.set_xlabel("Player")
+    ax.set_ylabel("Player")
+    ax.set_title("Pairwise sentence interaction heatmap")
+
+    fig.colorbar(image, ax=ax)
+    fig.tight_layout()
+
 
     if not show:
         return fig, ax

--- a/src/shapiq/plot/sentence.py
+++ b/src/shapiq/plot/sentence.py
@@ -213,6 +213,10 @@ def sentence_interaction_heatmap(
     """Plot a minimal pairwise interaction heatmap for sentence players."""
     # before: pass (Temporary placeholder)
     fig, ax = plt.subplots()
+    # 2d matix
+    n_words = len(words)
+
+    interaction_matrix = np.zeros((n_words, n_words))
 
     if not show:
         return fig, ax

--- a/src/shapiq/plot/sentence.py
+++ b/src/shapiq/plot/sentence.py
@@ -213,10 +213,21 @@ def sentence_interaction_heatmap(
     """Plot a minimal pairwise interaction heatmap for sentence players."""
     # before: pass (Temporary placeholder)
     fig, ax = plt.subplots()
-    # 2d matix
+    # 2d matrix init
     n_words = len(words)
 
     interaction_matrix = np.zeros((n_words, n_words))
+    
+    # diagonal
+    for i in range(n_words):
+        interaction_matrix[i, i] = interaction_values[(i,)]
+
+    #pairwise interaction
+    for i in range(n_words):
+        for j in range(i + 1, n_words):
+            value = interaction_values[(i, j)]
+            interaction_matrix[i, j] = value
+            interaction_matrix[j, i] = value
 
     if not show:
         return fig, ax

--- a/tests/shapiq/tests_unit/tests_plots/test_sentence.py
+++ b/tests/shapiq/tests_unit/tests_plots/test_sentence.py
@@ -66,5 +66,5 @@ def test_sentence_interaction_heatmap_empty_figure():
 
     assert isinstance(fig, plt.Figure)
     assert isinstance(ax, plt.Axes)
-    assert len(ax.images) == 1 #draw heatmap images in achxis
+    assert len(ax.images) == 1  # draw heatmap images in achxis
     plt.close(fig)

--- a/tests/shapiq/tests_unit/tests_plots/test_sentence.py
+++ b/tests/shapiq/tests_unit/tests_plots/test_sentence.py
@@ -77,3 +77,32 @@ def test_sentence_interaction_heatmap_word_count_mismatch():
 
     with pytest.raises(ValueError, match="Number of words must match number of players"):
         sentence_interaction_heatmap(iv, words[:-1], show=False)
+
+
+def test_sentence_interaction_heatmap_zero_values_show(monkeypatch):
+    """Test zero-valued heatmap and show=True path."""
+    words, _ = _text_values()
+
+    iv = InteractionValues(
+        n_players=len(words),
+        values=np.zeros(len(words)),
+        index="SV",
+        min_order=1,
+        max_order=1,
+        estimated=False,
+        baseline_value=0.0,
+    )
+
+    show_called = []
+
+    def fake_show():
+        show_called.append(True)
+
+    monkeypatch.setattr(plt, "show", fake_show)
+
+    result = sentence_interaction_heatmap(iv, words, show=True)
+
+    assert result is None
+    assert show_called == [True]
+
+    plt.close("all")

--- a/tests/shapiq/tests_unit/tests_plots/test_sentence.py
+++ b/tests/shapiq/tests_unit/tests_plots/test_sentence.py
@@ -66,4 +66,5 @@ def test_sentence_interaction_heatmap_empty_figure():
 
     assert isinstance(fig, plt.Figure)
     assert isinstance(ax, plt.Axes)
+    assert len(ax.images) == 1 #draw heatmap images in achxis
     plt.close(fig)

--- a/tests/shapiq/tests_unit/tests_plots/test_sentence.py
+++ b/tests/shapiq/tests_unit/tests_plots/test_sentence.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import matplotlib.pyplot as plt
 import numpy as np
+import pytest
 
 from shapiq.interaction_values import InteractionValues
-from shapiq.plot import sentence_plot
+from shapiq.plot import sentence_interaction_heatmap, sentence_plot
 
 
 def _text_values() -> tuple[list[str], InteractionValues]:
@@ -58,7 +59,6 @@ def test_sentence_plot():
 
 def test_sentence_interaction_heatmap_empty_figure():
     """Test that the sentence interaction heatmap returns a figure and axis."""
-    from shapiq.plot.sentence import sentence_interaction_heatmap
 
     words, iv = _text_values()
 
@@ -68,3 +68,12 @@ def test_sentence_interaction_heatmap_empty_figure():
     assert isinstance(ax, plt.Axes)
     assert len(ax.images) == 1  # draw heatmap images in achxis
     plt.close(fig)
+
+
+def test_sentence_interaction_heatmap_word_count_mismatch():
+    """Test that the heatmap raises if words and players do not match."""
+
+    words, iv = _text_values()
+
+    with pytest.raises(ValueError, match="Number of words must match number of players"):
+        sentence_interaction_heatmap(iv, words[:-1], show=False)

--- a/tests/shapiq/tests_unit/tests_plots/test_sentence.py
+++ b/tests/shapiq/tests_unit/tests_plots/test_sentence.py
@@ -54,3 +54,16 @@ def test_sentence_plot():
     assert isinstance(fig, plt.Figure)
     assert isinstance(ax, plt.Axes)
     plt.close(fig)
+
+
+def test_sentence_interaction_heatmap_empty_figure():
+    """Test that the sentence interaction heatmap returns a figure and axis."""
+    from shapiq.plot.sentence import sentence_interaction_heatmap
+
+    words, iv = _text_values()
+
+    fig, ax = sentence_interaction_heatmap(iv, words, show=False)
+
+    assert isinstance(fig, plt.Figure)
+    assert isinstance(ax, plt.Axes)
+    plt.close(fig)


### PR DESCRIPTION
## Summary

This PR addresses the pairwise interaction heatmap part of #9.

It adds a prototype visualization utility for sentence-level pairwise interaction values. The new `sentence_interaction_heatmap` function visualizes already computed `InteractionValues` over sentence players, such as words or tokens.

The function builds an interaction matrix, maps first-order values to the diagonal, maps pairwise interaction values to off-diagonal cells, and renders the result as a labeled heatmap.

## Implemented in this PR

- [x] Studied the existing `sentence_plot` utility in `src/shapiq/plot/sentence.py`
- [x] Added `sentence_interaction_heatmap`
- [x] Built an interaction matrix from provided `InteractionValues`
- [x] Mapped first-order values to the diagonal
- [x] Mapped pairwise interaction values to off-diagonal cells
- [x] Added word/token labels on both axes
- [x] Added centered color scaling with `coolwarm`
- [x] Added optional `max_score`
- [x] Added player-count validation
- [x] Exposed the function through `shapiq.plot`
- [x] Added unit tests for rendering and input validation

## Not included in this PR

- [ ] Token attribution bar plot
- [ ] Computing real interaction values from raw text
- [ ] Full TextImputer integration
- [ ] Word-token alignment
- [ ] SHAP / Captum / Inseq baseline comparison


## Usage

```python
from shapiq.plot import sentence_interaction_heatmap

fig, ax = sentence_interaction_heatmap(
    interaction_values=iv,
    words=words,
    show=False,
)
```

## Visual check

The following image was generated locally using the new `sentence_interaction_heatmap` function.

It is only an **illustrative example with manually defined fake `InteractionValues`.**  
The image is used to verify that the heatmap rendering, labels, colorbar, and centered color scale work as expected.  
It does not represent real model explanations.

<img width="1076" height="940" alt="3435fd11bc19702057cdbe3961632f4c" src="https://github.com/user-attachments/assets/12e1e0a0-c5ab-452c-a87b-9932dd48cb66" />


