### PR TITLE
Add token attribution bar plot

### DIFF
--- a/examples/language/plot_sentiment_analysis.py
+++ b/examples/language/plot_sentiment_analysis.py
@@ -105,6 +105,19 @@ sv.plot_sentence(words=token_names)
 sv_neg.plot_sentence(words=token_names_neg)
 
 # %%
+# Token Attribution Bar Plot
+# ---------------------------
+# The :func:`~shapiq.plot.token_attribution_bar_plot` shows each token's
+# first-order attribution as a horizontal bar. Positive values contribute
+# toward the predicted sentiment, while negative values contribute against it.
+
+shapiq.plot.token_attribution_bar_plot(sv, token_names)
+
+# %%
+
+shapiq.plot.token_attribution_bar_plot(sv_neg, token_names_neg)
+
+# %%
 # References
 # ----------
 # .. footbibliography::

--- a/src/shapiq/plot/__init__.py
+++ b/src/shapiq/plot/__init__.py
@@ -8,7 +8,7 @@ from .bar import bar_plot
 from .beeswarm import beeswarm_plot
 from .force import force_plot
 from .network import network_plot
-from .sentence import sentence_interaction_heatmap, sentence_plot
+from .sentence import sentence_interaction_heatmap, sentence_plot, token_attribution_bar_plot
 from .si_graph import si_graph_plot
 from .stacked_bar import stacked_bar_plot
 from .upset import upset_plot
@@ -28,4 +28,5 @@ __all__ = [
     "beeswarm_plot",
     # utils
     "abbreviate_feature_names",
+    "token_attribution_bar_plot",
 ]

--- a/src/shapiq/plot/sentence.py
+++ b/src/shapiq/plot/sentence.py
@@ -204,6 +204,66 @@ def sentence_plot(
     return None
 
 
+def token_attribution_bar_plot(
+    interaction_values: InteractionValues,
+    words: Sequence[str],
+    *,
+    show: bool = False,
+    max_score: float | None = None,
+) -> tuple[Figure, Axes] | None:
+    """Plot first-order token attributions as a horizontal bar plot.
+
+    Args:
+        interaction_values: The interaction values as an interaction object.
+        words: The words or tokens of the sentence.
+        show: Whether to show the plot. Defaults to ``False``.
+        max_score: The maximum absolute score used for the x-axis range. This is useful if multiple
+            token attribution plots should use the same scale. Defaults to ``None``.
+
+    Returns:
+        If ``show`` is ``True``, the function returns ``None``. Otherwise, it returns a tuple with
+        the figure and the axis of the plot.
+    """
+    n_words = len(words)
+
+    if n_words != interaction_values.n_players:
+        msg = (
+            f"Number of words must match number of players. "
+            f"Got {n_words} words and {interaction_values.n_players} players."
+        )
+        raise ValueError(msg)
+
+    attributions = np.array([interaction_values[(i,)] for i in range(n_words)])
+
+    max_abs_score = np.max(np.abs(attributions)) if max_score is None else max_score
+    if max_abs_score == 0:
+        max_abs_score = 1.0
+
+    colors = [RED.hex if value >= 0 else BLUE.hex for value in attributions]
+
+    fig, ax = plt.subplots()
+    y_positions = np.arange(n_words)
+
+    ax.barh(y_positions, attributions, color=colors)
+    ax.axvline(0, color="black", linewidth=0.8)
+
+    ax.set_yticks(y_positions)
+    ax.set_yticklabels(words)
+    ax.invert_yaxis()
+
+    ax.set_xlim(-max_abs_score, max_abs_score)
+    ax.set_xlabel("Attribution")
+    ax.set_title("Token attribution bar plot")
+
+    fig.tight_layout()
+
+    if not show:
+        return fig, ax
+
+    plt.show()
+    return None
+
+
 def sentence_interaction_heatmap(
     interaction_values: InteractionValues,
     words: Sequence[str],

--- a/tests/shapiq/tests_unit/tests_plots/test_sentence.py
+++ b/tests/shapiq/tests_unit/tests_plots/test_sentence.py
@@ -147,3 +147,26 @@ def test_sentence_interaction_heatmap_zero_values_show(monkeypatch):
     assert show_called == [True]
 
     plt.close("all")
+
+
+def test_token_attribution_bar_plot_zero_values():
+    """Test zero-valued token attribution bar plot."""
+    words, _ = _text_values()
+
+    iv = InteractionValues(
+        n_players=len(words),
+        values=np.zeros(len(words)),
+        index="SV",
+        min_order=1,
+        max_order=1,
+        estimated=False,
+        baseline_value=0.0,
+    )
+
+    fig, ax = token_attribution_bar_plot(iv, words, show=False)
+
+    assert isinstance(fig, plt.Figure)
+    assert isinstance(ax, plt.Axes)
+    assert ax.get_xlim() == (-1.0, 1.0)
+
+    plt.close(fig)

--- a/tests/shapiq/tests_unit/tests_plots/test_sentence.py
+++ b/tests/shapiq/tests_unit/tests_plots/test_sentence.py
@@ -7,7 +7,7 @@ import numpy as np
 import pytest
 
 from shapiq.interaction_values import InteractionValues
-from shapiq.plot import sentence_interaction_heatmap, sentence_plot
+from shapiq.plot import sentence_interaction_heatmap, sentence_plot, token_attribution_bar_plot
 
 
 def _text_values() -> tuple[list[str], InteractionValues]:
@@ -55,6 +55,47 @@ def test_sentence_plot():
     assert isinstance(fig, plt.Figure)
     assert isinstance(ax, plt.Axes)
     plt.close(fig)
+
+
+def test_token_attribution_bar_plot():
+    """Test that the token attribution bar plot returns a figure and axis."""
+    words, iv = _text_values()
+
+    fig, ax = token_attribution_bar_plot(iv, words, show=False)
+
+    assert isinstance(fig, plt.Figure)
+    assert isinstance(ax, plt.Axes)
+    assert len(ax.patches) == len(words)
+    assert ax.get_title() == "Token attribution bar plot"
+
+    plt.close(fig)
+
+
+def test_token_attribution_bar_plot_word_count_mismatch():
+    """Test that the token attribution bar plot raises if words and players do not match."""
+    words, iv = _text_values()
+
+    with pytest.raises(ValueError, match="Number of words must match number of players"):
+        token_attribution_bar_plot(iv, words[:-1], show=False)
+
+
+def test_token_attribution_bar_plot_show(monkeypatch):
+    """Test the show=True path of the token attribution bar plot."""
+    words, iv = _text_values()
+
+    show_called = []
+
+    def fake_show():
+        show_called.append(True)
+
+    monkeypatch.setattr(plt, "show", fake_show)
+
+    result = token_attribution_bar_plot(iv, words, show=True)
+
+    assert result is None
+    assert show_called == [True]
+
+    plt.close("all")
 
 
 def test_sentence_interaction_heatmap_empty_figure():


### PR DESCRIPTION
## Summary

This PR adds a simple token attribution bar plot for sentence-level explanations.

The new plot visualizes first-order token attributions as horizontal bars, with positive and negative values shown around a zero baseline. It complements the existing sentence plot and sentence interaction heatmap by providing a more numeric token-level visualization.

## Changes

- Added `token_attribution_bar_plot` in `src/shapiq/plot/sentence.py`
- Exported the new plot function via `shapiq.plot`
- Added unit tests for:
  - returned figure and axes
  - word/player count mismatch
  - `show=True` behavior
- Added the new plot to the sentiment analysis example

## Tests

```bash
PYTHONPATH=src pytest tests/shapiq/tests_unit/tests_plots/test_sentence.py
```

## Virtual
<img width="1276" height="1092" alt="Weixin Image_20260502153222_2773_32" src="https://github.com/user-attachments/assets/233159f3-8626-46fa-b0b5-33fc2c2fc387" />

